### PR TITLE
Removed escape characters from `.bash_aliases`.

### DIFF
--- a/dotfiles/.bash_aliases
+++ b/dotfiles/.bash_aliases
@@ -219,17 +219,17 @@ _after_command()
 
     if [ $exit_status -eq 0 ]
     then
-        local exit_symbol="[1;32m✓[0m"
+        local exit_symbol=$'\e[1;32m✓\e[m'
         local icon=dialog-information
     else
-        local exit_symbol="[1;31m✗[0m"
+        local exit_symbol=$'\e[1;31m✗\e[m'
         local icon=dialog-error
     fi
     local last_command=$(history 1 | sed -e 's/^[^]]*\] //' -e 's/\s\+$//')
 
     # Non-ASCII symbols may have to be treated as multi-byte characters,
     # depending on the shell.
-    printf "\r%*s\n" $((COLUMNS+15)) "$exit_symbol $last_command ◀ $breakup"
+    printf "\r%*s\n" $((COLUMNS+14)) "$exit_symbol $last_command ◀ $breakup"
     if [ $delay -ge 10000 -a $__window -ne $(getactivewindow) ]
     then
         notify-send -i $icon "CLI Ready" "$last_command • $breakup"

--- a/dotfiles/.bash_aliases
+++ b/dotfiles/.bash_aliases
@@ -6,7 +6,7 @@ alias less='command less -i'
 alias perfstat='perf stat -e task-clock,cycles,instructions,branches,branch-misses,cache-references,cache-misses '
 alias pgrep='command pgrep -il'
 alias ps='command ps a -c'
-alias time='/usr/bin/time -f "\n[3mReal %e s · User %U s · Kernel %S s · MRSS %M KiB · %P CPU · %c ICS · %w VCS[0m" '
+alias time=$'/usr/bin/time -f "\n\e[3mReal %e s · User %U s · Kernel %S s · MRSS %M KiB · %P CPU · %c ICS · %w VCS\e[m" '
 alias valgrind='command valgrind --leak-check=full --show-leak-kinds=all --track-origins=yes --verbose '
 
 alias f='watch -n 1 "command grep -F MHz /proc/cpuinfo | nl -n rz -w 2 | sort -k 5 -gr | sed s/^0/\ /g"'


### PR DESCRIPTION
These characters are not visible when viewing the file on GitHub. Furthermore, it is generally preferable to have their encoded versions in a text file. Another reason for avoiding them is that they mess up the colours when displaying the file in the terminal using `cat` or `git diff`.